### PR TITLE
package: specify files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "type": "git",
     "url": "git://github.com/xseignard/thermalPrinter.git"
   },
-  "main": "./src/printer.js",
+  "main": "src/printer.js",
+  "files": [ "src/" ],
   "author": "Xavier Seignard <xavier.seignard@gmail.com>",
   "contributors": [
     {


### PR DESCRIPTION
This will make sure that only the files necessary to run is uploaded to npm, and not the tests, demo and images.

This is what will be included in the package that is distributed to the end user:

- `README.md`
- `package.json`
- `src/`
  - `helpers.js`
  - `printer.js`

The benefits of this is faster downloads and less disk space wasted for the end users. This is especially good for deploying on the Tessel, Raspberry Pi or Intel Edison.