### PR TITLE
package: move serialport to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "async": "^0.9.0",
     "deasync": "0.0.10",
     "get-pixels": "^3.2.1",
-    "serialport": "^1.4.0",
     "sleep": "^1.1.5"
   },
   "devDependencies": {
@@ -40,6 +39,7 @@
     "codeclimate-test-reporter": "0.0.3",
     "istanbul": "^0.2.10",
     "jshint": "^2.5.1",
-    "mocha": "^1.19.0"
+    "mocha": "^1.19.0",
+    "serialport": "^1.4.0"
   }
 }


### PR DESCRIPTION
`serialport` is only used outside of the actual library so I moved it to `devDependencies`. This will make it not install when users are simply depending on your package, but still install when you run `npm install` in your project. Win win.