### PR TITLE
lib: get rid of sleep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "deasync": "0.0.10",
-    "get-pixels": "^3.2.1",
-    "sleep": "^1.1.5"
+    "get-pixels": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
Get rid of the sleep dependency.

The only downside is that this reduces the resolution of the sleep. It will round it upwards to the nearest millisecond.

*Work towards supporting Tessel (#7)*