### PR TITLE
Call print() without having to pass a callback function.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -87,7 +87,10 @@ Printer.prototype.print = function(callback) {
 		},
 		function(err) {
 			_self.commandQueue = [];
-			callback();
+
+			if(callback) {
+				callback();
+			}
 		}
 	);
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -89,7 +89,7 @@ Printer.prototype.print = function(callback) {
 			_self.commandQueue = [];
 
 			if(callback) {
-				callback();
+				callback(err);
 			}
 		}
 	);


### PR DESCRIPTION
I simply added a check to see if argument _callback_ exists before calling it.