### PR TITLE
Added Support for Buffers in .printImage

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -303,6 +303,10 @@ Printer.prototype.printImage = function(path, type){
 
 	// if we recieved a buffer
 	if (typeof path === 'object') {
+		if (type === undefined){
+			throw new Error('You must provide a MIME type when passing a buffer. Ex. (image/png)');
+		}
+		
 		// add required mime type
 		params[1] = type
 	}

--- a/src/printer.js
+++ b/src/printer.js
@@ -296,11 +296,19 @@ Printer.prototype.printLine = function (text) {
 	return this.printText(text).writeCommand(10);
 };
 
-Printer.prototype.printImage = function(path){
+Printer.prototype.printImage = function(path, type){
 	var done = false;
 
+	let params = [path]
+
+	// if we recieved a buffer
+	if (typeof path === 'object') {
+		// add required mime type
+		params[1] = type
+	}
+	
 	var _self = this;
-	getPixels(path, function(err, pixels){
+	getPixels(...params, function(err, pixels){
 		if(!err){
 			var width = pixels.shape[0];
 			var height = pixels.shape[1];


### PR DESCRIPTION
This commit adds support for passing buffers to .printImage(). get-pixels allows for the passing of buffers, however, you have to provide a mime type.

>### `require("get-pixels")(url[, type], cb(err, pixels))`
>* `url` is the path to the file.  It can be a relative path, an http url, a data url, or an [**in-memory Buffer**](http://nodejs.org/api/buffer.html).
>* `type` is an optional mime type for the image **(required when using a Buffer)**


## Test

```Javascript
// require sharp, just to test converting an image into a buffer
const sharp = require('sharp');

var SerialPort = require('serialport')
var serialPort = new SerialPort('/dev/ttyUSB0', {baudRate: 9600,})
var Printer = require('thermalprinter');

var path = __dirname + '/TEST IMAGE.png';


serialPort.on('open', function() {
  var printer = new Printer(serialPort);
  printer.on('ready', function() {
    // use sharp lib to auto resize image and export as buffer
    sharp(path).resize(384).png().toBuffer().then((buf) => {

      // print image buffer, notice the included mime type
      printer.printImage(buf, 'image/png').lineFeed(3).print()
    })
  });
});



```